### PR TITLE
Translate untraslatable strings in the UI

### DIFF
--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -35,7 +35,9 @@ msgid "Login"
 msgstr ""
 
 #: templates/frontend/include/login.html:7
-msgid "Access to backend administration stystem or logout"
+#, fuzzy
+#| msgid "Access to backend administration stystem or logout"
+msgid "Access to backend administration system or logout"
 msgstr ""
 
 #: templates/frontend/include/login.html:9

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -35,7 +35,9 @@ msgid "Login"
 msgstr ""
 
 #: frontend/templates/frontend/include/login.html:7
-msgid "Access to backend administration stystem or logout"
+#, fuzzy
+#| msgid "Access to backend administration stystem or logout"
+msgid "Access to backend administration system or logout"
 msgstr "Accedi alla sezione di amministrazione o esci"
 
 #: frontend/templates/frontend/include/login.html:9

--- a/templates/frontend/include/home.html
+++ b/templates/frontend/include/home.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load i18n %}
 <div id="home_wrapper">
     <div class="col-lg-7 col-md-7 col-sm-12 col-xs-12 home">
       <div class="home-block">
@@ -19,7 +20,7 @@
          <p>{{ generaldata.home_description|safe }}
              {% if home_image.author %}
              <br><br>
-             Photo by
+             {% trans 'Photo by' %}
              {% if home_image.author_url %}
              <a href="{{ home_image.author_url }}">
              {% endif %}
@@ -31,7 +32,7 @@
          </p>
         {% if powerd_by %}
          <p>
-             <a href="http://gis3w.it"><img style="float:right;" src="{% static 'frontend/images/logo_gis3w.png' %}"></a><span style="float:right; margin-right: 4px;">Powerd by</span></span>
+             <a href="http://gis3w.it"><img style="float:right;" src="{% static 'frontend/images/logo_gis3w.png' %}"></a><span style="float:right; margin-right: 4px;">{% trans 'Powered by' %}</span></span>
          </p>
         {% endif %}
          <!--

--- a/templates/frontend/include/login.html
+++ b/templates/frontend/include/login.html
@@ -4,7 +4,7 @@
 <div class="page_name tk-museo-sans">{% if user.is_authenticated %}{% trans 'Admin' %}{% else %}{% trans 'Login' %}{% endif %}</div>
 <h1 class="tk-source-sans-pro">
     {% if user.is_authenticated %}
-    {% trans 'Access to backend administration stystem or logout' %}
+    {% trans 'Access to backend administration system or logout' %}
     {% else %}
     {% trans 'Login to go backend administration system' %}
     {% endif %}

--- a/templates/frontend/include/login.html
+++ b/templates/frontend/include/login.html
@@ -28,8 +28,8 @@
         <form class="contact-form" action="{% url 'frontend-ajax-login' %}">
             <div class="login-errors hidden"></div>
             {% csrf_token %}
-            <input type="text" class="form-control" id="user" name="username" placeholder="USERNAME">
-            <input type="password" class="form-control" id="password" name="password" placeholder="PASSWORD">
+            <input type="text" class="form-control" id="user" name="username" placeholder="{% trans 'USERNAME' %}">
+            <input type="password" class="form-control" id="password" name="password" placeholder="{% trans 'PASSWORD' %}">
             <button class="submit-btn submit-login" type="submit" id="send" data-loading-text="<i class='fa fa-spinner fa-spin'></i> Sending..."> {% trans 'Login' %}</button>
         </form>
         <div id="result-message" role="alert"></div>

--- a/templates/frontend/include/menu.html
+++ b/templates/frontend/include/menu.html
@@ -2,14 +2,14 @@
 <div class="content-panel">
     <div class="content-box">
         <div class="icon-home">
-            <a href="#">Home</a>
+            <a href="#">{% trans 'Home' %}</a>
         </div>
         {% if user.is_authenticated %}
         <div class="icon-admin-home">
             <a href="{% url 'home' %}">{% trans 'Adminstration' %}</a>
         </div>
         {% endif %}
-        <div class="page_name">All Pages</div>
+        <div class="page_name">{% trans 'All Pages' %}</div>
             <h1 class="tk-source-sans-pro"></h1>
         <div class="paragraphs"></div>
     </div>


### PR DESCRIPTION
Some strings in the UI were not translatable. This is now fixed.

In addition, fixed a typo in the base string and already existing translations.